### PR TITLE
fix(2019): remove wrong reference to menu

### DIFF
--- a/content/pages/2019/index.md
+++ b/content/pages/2019/index.md
@@ -83,7 +83,6 @@ Join us on social media:
 | Regular (till Aug, 5th)     | 100 €    | 110 €               | 250 €    |
 | Late (till Aug, 22nd)       | 135 €    | 135 €               | 300 €    |
 
-Social event: 35 €
 
 (*)  After registration, please send your student qualifying proof at
 <a href="mailto:students@euroscipy.org">students@euroscipy.org</a>
@@ -104,7 +103,7 @@ Check [here](social_event.html) for more information.
 
 ### Visa letters<a name="visa"></a>
 
-If you require a visa letter to be able to travel to the conference, please fill in 
+If you require a visa letter to be able to travel to the conference, please fill in
 [this form](https://forms.gle/6VcSPh5sMSzNtJap9) and we will get back to you with the letter as soon as possible.
 
 ### Questions <a name="questions"></a>

--- a/content/pages/2019/social_event.md
+++ b/content/pages/2019/social_event.md
@@ -9,12 +9,12 @@ Buy tickets for the social event [here](https://ti.to/acpyss/euroscipy-2019).
 
 There will be **2 separate dinners** during the conference, one **on Tuesday (02/09/2019)**
 for the people who come to the workshops and another **on Thursday (05/09/2019)**
-for the people who come to the talks. 
+for the people who come to the talks.
 However is up to you when you want to go, you could also come twice.
 
 #### Location
 
-We will have a typical cider house dinner in [Txoko Piperrak](http://www.txokopiperrak.com/). 
+We will have a typical cider house dinner in [Txoko Piperrak](http://www.txokopiperrak.com/).
 
 We can meet 10 minutes before the start time at the front of the conference
 venue or we can meet there directly.
@@ -24,7 +24,7 @@ venue or we can meet there directly.
 
 #### Dinner menu
 
-The menu we chose is a traditional cider house menu ([Menu 1](http://www.txokopiperrak.com/#menu)):
+The menu we chose is a traditional cider house menu:
 
 - Txistorra (Basque Chorizo)
 - Morcilla con pimientos (Blood sausage with Pepper)


### PR DESCRIPTION
This PR removes the wrong reference to the menu for the social event and also removes the price of the social event ticket in the index, because we are considering reducing it.