### PR TITLE
Updating make rsync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ OUTPUTDIR=$(BASEDIR)/output
 CONFFILE=$(BASEDIR)/pelicanconf.py
 PUBLISHCONF=$(BASEDIR)/publishconf.py
 
-SSH_HOST=
+SSH_HOST ?= euroscipy.g-node.org
 SSH_PORT=22
-SSH_USER=
+SSH_USER ?= $(USER)
 SSH_TARGET_DIR=/web/static/
 
 DEBUG ?= 0
@@ -66,7 +66,7 @@ publish:
 	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
 
 rsync: publish
-	rsync -e "ssh -p $(SSH_PORT)" -P -auvz --delete --chown=:euroscipyweb --chmod=g+rwx --exclude="2013" --exclude="2014" --exclude="2015" --exclude="2016" --exclude="2016_static_20160429" $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
+	rsync -Oe "ssh -p $(SSH_PORT)" -P -auvz --delete --chown=:euroscipyweb --chmod=g+rwx --exclude="2013" --exclude="2014" --exclude="2015" --exclude="2016" --exclude="2016_static_20160429" $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
 
 
 .PHONY: html help clean regenerate serve devserver publish rsync


### PR DESCRIPTION
@pdebuyl with the changes to the group permissions you made everything seems to work fine now, except that I was getting the error:
```
rsync: failed to set times on "/web/static/.": Operation not permitted (1)
```
Not an expert on `rsync`, but looks like it can be fixed with the `-O` parameter. Not sure if this has any implication, but I'm adding it in this PR.

Also, I'm giving default values to `SSH_USER` and and `SSH_HOST`, so we can just simply type `make rsync` if our local user and the one in the server are the same.

Are you happy with these changes? They make deployments really easy for me now. :)