### PR TITLE
Inconsistency between program and schedule on pretalx

### DIFF
--- a/content/pages/2019/program.md
+++ b/content/pages/2019/program.md
@@ -99,7 +99,7 @@ With the tutorial tickets you can attend any tutorial of any track.
 
 <tr>
     <td>09:00</td>
-    <td><a href="https://pretalx.com/euroscipy-2019/talk/RHUPZ3/">A Tour of the Data Visualization Ecosystem of Python</a><br/>Giovanni De Gasperis</td>
+    <td><a href="https://pretalx.com/euroscipy-2019/talk/WSNPK7">Introduction to SciPy</a><br />Gert-Ludwig Ingold</td>
     <td><a href="https://pretalx.com/euroscipy-2019/talk/ZHQALW/">Sufficiently Advanced Testing with Hypothesis</a><br/>Zac Hatfield-Dodds</td>
     <td><a href="https://pretalx.com/euroscipy-2019/talk/YKPNEE/">Introduction to geospatial data analysis with GeoPandas and the PyData stack</a><br/>Joris Van den Bossche</td>
 </tr>
@@ -111,7 +111,7 @@ With the tutorial tickets you can attend any tutorial of any track.
 
 <tr>
     <td>11:00</td>
-    <td><a href="https://pretalx.com/euroscipy-2019/talk/WSNPK7">Introduction to SciPy</a><br />Gert-Ludwig Ingold</td>
+    <td><a href="https://pretalx.com/euroscipy-2019/talk/RHUPZ3/">A Tour of the Data Visualization Ecosystem of Python</a><br/>Giovanni De Gasperis</td>
     <td><a href="https://pretalx.com/euroscipy-2019/talk/M3RZXE/">Effectively using matplotlib</a><br/>Tim Hoffmann</td>
     <td><a href="https://pretalx.com/euroscipy-2019/talk/SMLGVL/">Astronomical Image Processing</a><br/>Samuel Farrens</td>
 </tr>


### PR DESCRIPTION
There is an inconsistency between the web program and the schedule on pretalx for the tutorials on Tuesday morning in track 2 (Baroja). This PR provides the change required to be consistent with the schedule on pretalx. Whether this PR should be merged depends on which version of the schedule is the correct one. As one of the two speakers concerned, I am completely open for either of the two versions. But the information on the webpage and the abstract page produced by pretalx should be consistent to not confuse participants.